### PR TITLE
Fixed broken image URI's

### DIFF
--- a/TVDbClient.h
+++ b/TVDbClient.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #define BASE_URI @"http://www.thetvdb.com/api/"
+#define BASE_IMAGE_URI @"http://www.thetvdb.com/"
 
 @class XMLReader;
 

--- a/TVDbImage.m
+++ b/TVDbImage.m
@@ -26,12 +26,12 @@
 
 - (NSString *)url
 {
-    return [BASE_URI stringByAppendingString:_url];
+    return [BASE_IMAGE_URI stringByAppendingString:_url];
 }
 
 - (NSString *)thumbnailUrl
 {
-    return [BASE_URI stringByAppendingString:[NSString stringWithFormat:@"banners/_cache/%a", _url]];
+    return [BASE_IMAGE_URI stringByAppendingString:[NSString stringWithFormat:@"banners/_cache/%@", _url]];
 }
 
 @end


### PR DESCRIPTION
TheTVDb changed their image URL's to no longer be prefixed with /api/. Also the %a in the string format for the URI didn't work for me.
