### PR TITLE
TVDb finByName: - Data.Series to Data

### DIFF
--- a/TVDbShow.m
+++ b/TVDbShow.m
@@ -92,7 +92,7 @@
 
 + (NSMutableArray *)findByName:(NSString *)name
 {
-    id response = [[[TVDbClient sharedInstance] requestURL:[self searchTermUrl:name]] retrieveForPath:@"Data.Series"];
+    id response = [[[TVDbClient sharedInstance] requestURL:[self searchTermUrl:name]] retrieveForPath:@"Data"];
 
     NSMutableArray *shows = [NSMutableArray array];
     if ([response isKindOfClass:[NSDictionary class]])


### PR DESCRIPTION
Same as before, it is actually pretty useless since there is not anything else but Series when searching by name, but for consistency.
